### PR TITLE
Implement TooManyRequestsResponse

### DIFF
--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -1,5 +1,6 @@
 module Bunq
   class UnexpectedResponse < StandardError; end
   class AbsentResponseSignature < StandardError; end
+  class TooManyRequestsResponse < StandardError; end
   class Timeout < StandardError; end
 end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -101,6 +101,10 @@ module Bunq
     end
 
     def handle_response(response, _request, _result, &block)
+      if Bunq::configuration.sandbox && response.code == 409
+        fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
+      end
+
       case response.code
       when 200, 201
         if block_given?
@@ -108,6 +112,8 @@ module Bunq
         else
           JSON.parse(response.body)
         end
+      when 429
+        fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       else
         fail UnexpectedResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -101,18 +101,13 @@ module Bunq
     end
 
     def handle_response(response, _request, _result, &block)
-      if Bunq::configuration.sandbox && response.code == 409
-        fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
-      end
-
-      case response.code
-      when 200, 201
+      if response.code == 200 || response.code == 201
         if block_given?
           yield(response)
         else
           JSON.parse(response.body)
         end
-      when 429
+      elsif (response.code == 409 && Bunq::configuration.sandbox) || response.code == 429
         fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       else
         fail UnexpectedResponse.new(code: response.code, headers: response.raw_headers, body: response.body)

--- a/lib/bunq/signature.rb
+++ b/lib/bunq/signature.rb
@@ -30,9 +30,7 @@ module Bunq
       sorted_bunq_headers = response.raw_headers.select(&method(:verifiable_header?)).sort.to_h.map { |k, v| "#{k.to_s.split('-').map(&:capitalize).join('-')}: #{v.first}" }
       data = %Q{#{response.code}\n#{sorted_bunq_headers.join("\n")}\n\n#{response.body}}
 
-      if response.code == 409 || response.code == 429
-        fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body) 
-      end
+      return if response.code == 409 || response.code == 429
 
       signature_headers = response.raw_headers.find { |k, _| k.to_s.downcase == BUNQ_SERVER_SIGNATURE_RESPONSE_HEADER }
       fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body) unless signature_headers

--- a/lib/bunq/signature.rb
+++ b/lib/bunq/signature.rb
@@ -30,6 +30,10 @@ module Bunq
       sorted_bunq_headers = response.raw_headers.select(&method(:verifiable_header?)).sort.to_h.map { |k, v| "#{k.to_s.split('-').map(&:capitalize).join('-')}: #{v.first}" }
       data = %Q{#{response.code}\n#{sorted_bunq_headers.join("\n")}\n\n#{response.body}}
 
+      if response.code == 409 || response.code == 429
+        fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body) 
+      end
+
       signature_headers = response.raw_headers.find { |k, _| k.to_s.downcase == BUNQ_SERVER_SIGNATURE_RESPONSE_HEADER }
       fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body) unless signature_headers
 

--- a/spec/bunq/resource_spec.rb
+++ b/spec/bunq/resource_spec.rb
@@ -31,4 +31,28 @@ describe Bunq::Resource do
       expect { resource.post({}) }.to(raise_error(Bunq::Timeout)) { |e| expect(e.cause).to be_a_kind_of RestClient::Exceptions::Timeout }
     end
   end
+
+  context 'too many requests sandbox response' do
+    before do
+      Bunq.configure do |config|
+        config.sandbox = true
+      end
+    end
+
+    it 'fails' do
+      stub_request(:get, "#{url}/timeout")
+        .to_return({ status: 409 })
+
+      expect { resource.get({}) }.to raise_error(Bunq::TooManyRequestsResponse)
+    end
+  end
+
+  context 'too many requests production response' do
+    it 'fails' do
+      stub_request(:get, "#{url}/timeout")
+        .to_return({ status: 429 })
+
+      expect { resource.get({}) }.to raise_error(Bunq::TooManyRequestsResponse)
+    end
+  end
 end

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -126,6 +126,23 @@ describe Bunq::Signature do
       end
     end
 
+    context 'given a too many requests sandbox response' do
+      let(:code) { 409 }
+
+      it 'fails' do
+        expect { subject }.to raise_error(Bunq::TooManyRequestsResponse)
+      end
+    end
+
+    context 'given a too many requests production response' do
+      let(:code) { 429 }
+
+      it 'fails' do
+        expect { subject }.to raise_error(Bunq::TooManyRequestsResponse)
+      end
+    end
+
+
     context 'given an absent server signature' do
       let(:headers) { {} }
 

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -126,23 +126,6 @@ describe Bunq::Signature do
       end
     end
 
-    context 'given a too many requests sandbox response' do
-      let(:code) { 409 }
-
-      it 'fails' do
-        expect { subject }.to raise_error(Bunq::TooManyRequestsResponse)
-      end
-    end
-
-    context 'given a too many requests production response' do
-      let(:code) { 429 }
-
-      it 'fails' do
-        expect { subject }.to raise_error(Bunq::TooManyRequestsResponse)
-      end
-    end
-
-
     context 'given an absent server signature' do
       let(:headers) { {} }
 


### PR DESCRIPTION
- Implemented TooManyRequestsResponse as error
- It’s raised when the api returns either 409 or 429. (Sandbox & Production)

This is a proposal for #4.