### PR TITLE
Only require api_key when mandatory

### DIFF
--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -40,8 +40,6 @@ module Bunq
       yield(configuration)
 
       configuration.base_url = Configuration::SANDBOX_BASE_URL if configuration.sandbox
-
-      fail 'api_key is mandatory' unless self.configuration.api_key
     end
 
     def reset_configuration

--- a/lib/bunq/device_servers.rb
+++ b/lib/bunq/device_servers.rb
@@ -15,6 +15,7 @@ module Bunq
     # https://doc.bunq.com/api/1/call/device-server/method/post
     def create(description)
       fail ArgumentError.new('description is required') unless description
+      fail 'Cannot create session, please add the api_key to your configuration' unless @client.configuration.api_key
 
       @resource.post(description: description, secret: @client.configuration.api_key)['Response']
     end

--- a/lib/bunq/session_servers.rb
+++ b/lib/bunq/session_servers.rb
@@ -10,7 +10,7 @@ module Bunq
     ##
     # https://doc.bunq.com/api/1/call/session-server/method/post
     def create
-      fail 'Cannot create session, please provide api_key to Bunq::Client' unless @api_key
+      fail 'Cannot create session, please add the api_key to your configuration' unless @api_key
       @resource.post(secret: @api_key)['Response']
     end
   end


### PR DESCRIPTION
When performing the installation an api_key is not always available. Fixes #10.