### PR TITLE
Allow usage without global config

### DIFF
--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -55,14 +55,6 @@ module Bunq
       fail "No configuration! Call Bunq.configure first." unless configuration
       Client.new(configuration)
     end
-
-    ##
-    # Returns a new instance of +Signature+
-    #
-    def signature
-      fail "No configuration! Call Bunq.configure first." unless configuration
-      Signature.new(configuration.private_key, configuration.server_public_key)
-    end
   end
 
   ##
@@ -111,8 +103,6 @@ module Bunq
       # Timeout in seconds to wait for bunq api. Defaults to +DEFAULT_TIMEOUT+
       :timeout
 
-
-
     def initialize
       @sandbox = false
       @base_url = PRODUCTION_BASE_URL
@@ -133,8 +123,10 @@ module Bunq
 
     attr_accessor :current_session
     attr_reader :configuration
+    attr_reader :signature
 
     def initialize(configuration)
+      fail ArgumentError.new('configuration is required') unless configuration
       @configuration = configuration
     end
 
@@ -184,6 +176,10 @@ module Bunq
     def with_session(&block)
       ensure_session!
       block.call
+    end
+
+    def signature
+      Signature.new(configuration.private_key, configuration.server_public_key)
     end
 
     def headers

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -82,7 +82,7 @@ module Bunq
     end
 
     def sign_request(verb, params, request_id_header, payload = nil)
-      Bunq.signature.create(
+      client.signature.create(
         verb,
         encode_params(@path, params),
         @resource.headers.merge(request_id_header),
@@ -96,7 +96,7 @@ module Bunq
     end
 
     def verify_and_handle_response(response, request, result, &block)
-      Bunq.signature.verify!(response) unless client.configuration.disable_response_signature_verification
+      client.signature.verify!(response) unless client.configuration.disable_response_signature_verification
       handle_response(response, request, result, &block)
     end
 

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -18,7 +18,7 @@ describe Bunq::Signature do
     let(:headers) { signable_headers }
     let(:body) { '{"amount": 10}' }
 
-    subject { Bunq.signature.create(verb, path, headers, body) }
+    subject { Bunq.client.signature.create(verb, path, headers, body) }
 
     let(:expected_signature) do
       'o5AXc4Ag72GzfzXwDbvlEck3SnrEILHVjmc6wJhjZVGn+rtPmAilCKQiSvneo2VbjwuP2vHJdZEQk4NF/1PmrVByUjdmCF/' \
@@ -112,7 +112,7 @@ describe Bunq::Signature do
         body: body
       )
     end
-    subject { Bunq.signature.verify!(response) }
+    subject { Bunq.client.signature.verify!(response) }
 
     it 'does not raise an error' do
       expect { subject }.to_not raise_error


### PR DESCRIPTION
To support usage with different configs the signature
should be bound to the client. Fixes #8.