### PR TITLE
Added ResponseError class

### DIFF
--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -6,7 +6,7 @@ module Bunq
 
     def initialize(msg = "Response error", code: nil, headers: nil, body: nil)
       @code = code
-      @headers = headers
+      @headers = headers || {}
       @body = body
       super(msg)
     end

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -1,6 +1,19 @@
 module Bunq
-  class UnexpectedResponse < StandardError; end
+  class UnexpectedResponse < StandardError;
+    attr_reader :code
+    attr_reader :headers
+    attr_reader :body
+
+    def initialize(msg = "Unexpected response", code: nil, headers: nil, body: nil)
+      @code = code
+      @headers = headers
+      @body = body
+      super(msg)
+    end
+  end
+
   class AbsentResponseSignature < StandardError; end
   class TooManyRequestsResponse < StandardError; end
   class Timeout < StandardError; end
+  class Unauthorized < StandardError; end
 end

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -8,7 +8,7 @@ module Bunq
       @code = code
       @headers = headers || {}
       @body = body
-      super(msg)
+      super("#{msg}: #{body}")
     end
 
     # Returns the parsed body if it is a JSON document, nil otherwise.

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -14,7 +14,7 @@ module Bunq
     # Returns the parsed body if it is a JSON document, nil otherwise.
     # @param opts [Hash] Optional options that are passed to `JSON.parse`.
     def parsed_body(opts = {})
-      JSON.parse(@body, opts) if @body && @headers['content-type'] == 'application/json'
+      JSON.parse(@body, opts) if @body && @headers['content-type'].include?('application/json')
     end
 
     # Returns an array of errors returned from the API, or nil if no errors are returned.

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -14,7 +14,7 @@ module Bunq
     # Returns the parsed body if it is a JSON document, nil otherwise.
     # @param opts [Hash] Optional options that are passed to `JSON.parse`.
     def parsed_body(opts = {})
-      JSON.parse(@body, opts) if @body && @headers['Content-Type'] == 'application/json'
+      JSON.parse(@body, opts) if @body && @headers['content-type'] == 'application/json'
     end
 
     # Returns an array of errors returned from the API, or nil if no errors are returned.

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -14,7 +14,7 @@ module Bunq
     # Returns the parsed body if it is a JSON document, nil otherwise.
     # @param opts [Hash] Optional options that are passed to `JSON.parse`.
     def parsed_body(opts = {})
-      JSON.parse(@body, opts) if @body && @headers['content-type'].include?('application/json')
+      JSON.parse(@body, opts) if @body && @headers['content-type'] && @headers['content-type'].include?('application/json')
     end
 
     # Returns an array of errors returned from the API, or nil if no errors are returned.

--- a/spec/bunq/response_error_spec.rb
+++ b/spec/bunq/response_error_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Bunq::ResponseError do
+  context 'with a JSON body' do
+    let(:error) {
+      json = '{"Error": "foo"}'
+      Bunq::ResponseError.new(code: 400, headers: { 'Content-Type' => 'application/json' }, body: json)
+    }
+
+    describe '#parsed_body' do
+      it 'returns the parsed JSON' do
+        parsed_body = error.parsed_body
+        expect(parsed_body).to eq({ "Error" => "foo" })
+      end
+    end
+
+    describe '#errors' do
+      it 'returns the Error field from the JSON body' do
+        errors = error.errors
+        expect(errors).to eq("foo")
+      end
+    end
+  end
+
+  context 'without a JSON body' do
+    let(:error) {
+      Bunq::ResponseError.new(code: 400, headers: nil, body: "")
+    }
+
+    describe '#parsed_body' do
+      it 'returns nil' do
+        parsed_body = error.parsed_body
+        expect(parsed_body).to eq(nil)
+      end
+    end
+
+    describe '#errors' do
+      it 'returns nil' do
+        errors = error.errors
+        expect(errors).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/bunq/response_error_spec.rb
+++ b/spec/bunq/response_error_spec.rb
@@ -4,7 +4,7 @@ describe Bunq::ResponseError do
   context 'with a JSON body' do
     let(:error) {
       json = '{"Error": "foo"}'
-      Bunq::ResponseError.new(code: 400, headers: { 'Content-Type' => 'application/json' }, body: json)
+      Bunq::ResponseError.new(code: 400, headers: { 'content-type' => ['application/json'] }, body: json)
     }
 
     describe '#parsed_body' do


### PR DESCRIPTION
I've created a `ResponseError` class as a base class for more detailed response errors. It includes the http status code, the headers, and the raw body. Apart from that, it also includes a `parsed_body` attribute which returns the parsed body if it is JSON, and an `errors` attribute to get errors returned from the API.

Unfortunately I don't have access to the Bunq API now, so I cannot test this against the API.