### PR TITLE
Added Client::SessionData struct

### DIFF
--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -22,6 +22,7 @@ require_relative './attachment_public_content.rb'
 #
 #   Bunq.configure do |config|
 #     config.api_key = 'YOUR_APIKEY'
+#     config.installation_token = 'YOUR_INSTALLATION_TOKEN'
 #     config.private_key = 'YOUR PRIVATE KEY'
 #     config.server_public_key = 'SERVER PUBLIC KEY'
 #   end

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -22,7 +22,6 @@ require_relative './attachment_public_content.rb'
 #
 #   Bunq.configure do |config|
 #     config.api_key = 'YOUR_APIKEY'
-#     config.installation_token = 'YOUR_INSTALLATION_TOKEN'
 #     config.private_key = 'YOUR PRIVATE KEY'
 #     config.server_public_key = 'SERVER PUBLIC KEY'
 #   end


### PR DESCRIPTION
In some cases you might want to store the current_session of a client, so it can be reused later. This PR introduces a Client::SessionData struct that holds only the necessary session data.

Because the `token`, `user_id` and `expires_in` are extracted, it makes it easier to store this data (potentially in an RDBMS) instead of having to store a big hunk of JSON.