### PR TITLE
Implement request encryption and card resource

### DIFF
--- a/bunq-client.gemspec
+++ b/bunq-client.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.16.1"
+  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "webmock", "~> 3.2.1"

--- a/lib/bunq/card.rb
+++ b/lib/bunq/card.rb
@@ -1,0 +1,15 @@
+module Bunq
+  class Card
+    def initialize(parent_resource, id)
+      @resource = parent_resource.append("/card/#{id}")
+    end
+
+    def show
+      @resource.with_session { @resource.get }['Response']
+    end
+
+    def update(card)
+      @resource.with_session { @resource.put(card, encrypt: true) }['Response']
+    end
+  end
+end

--- a/lib/bunq/cards.rb
+++ b/lib/bunq/cards.rb
@@ -1,0 +1,11 @@
+module Bunq
+  class Cards
+    def initialize(parent_resource)
+      @resource = parent_resource.append("/card")
+    end
+
+    def index
+      @resource.with_session { @resource.get }['Response']
+    end
+  end
+end

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -7,6 +7,7 @@ require_relative './resource'
 require_relative './installations'
 require_relative './installation'
 require_relative './device_servers'
+require_relative './encryptor'
 require_relative './session_servers'
 require_relative './user'
 require_relative './user_company'
@@ -22,7 +23,7 @@ require_relative './attachment_public_content.rb'
 #
 #   Bunq.configure do |config|
 #     config.api_key = 'YOUR_APIKEY'
-#     config.installation_token = 'YOUR_INSTALLATION_TOKEN' 
+#     config.installation_token = 'YOUR_INSTALLATION_TOKEN'
 #     config.private_key = 'YOUR PRIVATE KEY'
 #     config.server_public_key = 'SERVER PUBLIC KEY'
 #   end
@@ -121,7 +122,6 @@ module Bunq
 
     attr_accessor :current_session
     attr_reader :configuration
-    attr_reader :signature
 
     def initialize(configuration)
       fail ArgumentError.new('configuration is required') unless configuration
@@ -177,7 +177,11 @@ module Bunq
     end
 
     def signature
-      Signature.new(configuration.private_key, configuration.server_public_key)
+      @signature ||= Signature.new(configuration.private_key, configuration.server_public_key)
+    end
+
+    def encryptor
+      @encryptor ||= Encryptor.new(configuration.server_public_key)
     end
 
     def headers

--- a/lib/bunq/encryptor.rb
+++ b/lib/bunq/encryptor.rb
@@ -1,0 +1,53 @@
+module Bunq
+  class Encryptor
+    HEADER_CLIENT_ENCRYPTION_HMAC = 'X-Bunq-Client-Encryption-Hmac'
+    HEADER_CLIENT_ENCRYPTION_IV = 'X-Bunq-Client-Encryption-Iv'
+    HEADER_CLIENT_ENCRYPTION_KEY = 'X-Bunq-Client-Encryption-Key'
+    AES_ENCRYPTION_METHOD = 'aes-256-cbc'
+    HMAC_ALGORITHM = 'sha1'
+
+    def initialize(server_public_key)
+      fail ArgumentError.new('server_public_key is mandatory') unless server_public_key
+
+      @server_public_key = OpenSSL::PKey::RSA.new(server_public_key)
+    end
+
+    def encrypt(body)
+      headers = {}
+
+      iv, key, encrypted_body = encrypt_body(body)
+
+      headers[HEADER_CLIENT_ENCRYPTION_IV] = Base64.strict_encode64(iv)
+
+      encrypted_key = server_public_key.public_encrypt(key)
+      headers[HEADER_CLIENT_ENCRYPTION_KEY] = Base64.strict_encode64(encrypted_key)
+
+      digest = hmac(key, iv + encrypted_body)
+      headers[HEADER_CLIENT_ENCRYPTION_HMAC] = Base64.strict_encode64(digest)
+
+      [encrypted_body, headers]
+    end
+
+    private
+
+    attr_reader :server_public_key
+
+    def encrypt_body(body)
+      cipher = OpenSSL::Cipher.new(AES_ENCRYPTION_METHOD)
+      cipher.encrypt
+
+      iv = cipher.random_iv
+      key = cipher.random_key
+
+      encrypted_body = cipher.update(body) + cipher.final
+
+      [iv, key, encrypted_body]
+    end
+
+    def hmac(key, content)
+      hmac = OpenSSL::HMAC.new(key, OpenSSL::Digest.new(HMAC_ALGORITHM))
+      hmac << content
+      hmac.digest
+    end
+  end
+end

--- a/lib/bunq/installations.rb
+++ b/lib/bunq/installations.rb
@@ -7,7 +7,7 @@ module Bunq
     def create(public_key)
       fail ArgumentError.new('public_key is required') unless public_key
 
-      @resource.post({client_public_key: public_key}, true)['Response']
+      @resource.post({client_public_key: public_key}, skip_verify: true)['Response']
     end
 
     def index

--- a/lib/bunq/user.rb
+++ b/lib/bunq/user.rb
@@ -4,6 +4,8 @@ require_relative 'monetary_accounts'
 require_relative 'draft_share_invite_bank'
 require_relative 'draft_share_invite_banks'
 require_relative 'certificate_pinned'
+require_relative 'card'
+require_relative 'cards'
 
 module Bunq
   class User
@@ -29,6 +31,14 @@ module Bunq
 
     def certificate_pinned
       Bunq::CertificatePinned.new(@resource)
+    end
+
+    def card(id)
+      Bunq::Card.new(@resource, id)
+    end
+
+    def cards
+      Bunq::Cards.new(@resource)
     end
 
     def show

--- a/spec/bunq/encryptor_spec.rb
+++ b/spec/bunq/encryptor_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Bunq::Encryptor do
+  let(:body) { '{"amount": 10}' }
+
+  subject { Bunq.client.encryptor }
+
+  describe '#encrypt' do
+    let(:server_private_key) { OpenSSL::PKey::RSA.new(IO.read('spec/bunq/fixtures/server-test-private.pem')) }
+
+    let(:encryption_data)    { subject.encrypt(body) }
+    let(:encrypted_body)     { encryption_data.first }
+    let(:encryption_headers) { encryption_data.last }
+
+    let(:iv)            { Base64.strict_decode64(encryption_headers[described_class::HEADER_CLIENT_ENCRYPTION_IV]) }
+    let(:encrypted_key) { Base64.strict_decode64(encryption_headers[described_class::HEADER_CLIENT_ENCRYPTION_KEY]) }
+    let(:hmac)          { Base64.strict_decode64(encryption_headers[described_class::HEADER_CLIENT_ENCRYPTION_HMAC]) }
+
+    let(:key) { server_private_key.private_decrypt(encrypted_key) }
+
+    it 'allows decryption using the server private key' do
+      cipher = OpenSSL::Cipher.new(described_class::AES_ENCRYPTION_METHOD)
+      cipher.decrypt
+
+      cipher.iv = iv
+      cipher.key = key
+
+      decrypted_body = cipher.update(encrypted_body) + cipher.final
+
+      expect(decrypted_body).to eq(body)
+    end
+
+    it 'returns a valid HMAC' do
+      test_hmac = OpenSSL::HMAC.new(key, OpenSSL::Digest.new(described_class::HMAC_ALGORITHM))
+      test_hmac << iv
+      test_hmac << encrypted_body
+
+      expect(test_hmac.digest).to eq(hmac)
+    end
+  end
+end


### PR DESCRIPTION
Updating a card using `PUT /user/{userID}/card/{itemId}` requires the request to be encrypted.

The encryption logic was based on the PHP SDK implementation at https://github.com/bunq/sdk_php/blob/ef02fbc2e1445290d8779629b5b0e34a5e19ee54/src/Http/Handler/RequestHandlerEncryption.php#L45-L66.

I haven't added tests for `Bunq::Cards` and `Bunq::Card` yet because I don't currently have access to a Sandbox account, and I'd rather not use my actual data for the fixtures. I'm also not totally sure how valuable testing each individual resource is when the spec ultimately fakes the entire request :)