### PR TITLE
Prevent endless loop when paging

### DIFF
--- a/lib/bunq/paginated.rb
+++ b/lib/bunq/paginated.rb
@@ -40,10 +40,20 @@ module Bunq
           pagination = result['Pagination']
           fail MissingPaginationObject unless pagination
 
-          last_page = !pagination['older_url']
-          next_params = params.merge(older_id: param('older_id', pagination['older_url'])) unless last_page
+          last_page = !pagination[paging_url(params)]
+          next_params = params.merge(:"#{paging_id(params)}" => param(paging_id(params), pagination[paging_url(params)])) unless last_page
         end
       end
+    end
+
+    def paging_url(params)
+      return 'newer_url' if params[:newer_id]
+      'older_url'
+    end
+
+    def paging_id(params)
+      return 'newer_id' if params[:newer_id]
+      'older_id'
     end
 
     def param(name, url)

--- a/spec/bunq/fixtures/pagination-page-1.list.json
+++ b/spec/bunq/fixtures/pagination-page-1.list.json
@@ -1,0 +1,15 @@
+{
+  "Pagination": {
+    "future_url": "/v1/user/1/monetary-account/2/payment?count=1&newer_id=42",
+    "newer_url": null,
+    "older_url": "/v1/user/1/monetary-account/2/payment?count=1&older_id=42"
+  },
+
+  "Response": [
+    {
+      "Payment": {
+        "id": 42
+      }
+    }
+  ]
+}

--- a/spec/bunq/fixtures/pagination-page-2.list.json
+++ b/spec/bunq/fixtures/pagination-page-2.list.json
@@ -1,0 +1,15 @@
+{
+  "Pagination": {
+    "future_url": null,
+    "newer_url": "/v1/user/1/monetary-account/2/payment?count=1&newer_id=120",
+    "older_url": "/v1/user/1/monetary-account/2/payment?count=1&older_id=120"
+  },
+
+  "Response": [
+    {
+      "Payment": {
+        "id": 120
+      }
+    }
+  ]
+}

--- a/spec/bunq/fixtures/pagination-page-3.list.json
+++ b/spec/bunq/fixtures/pagination-page-3.list.json
@@ -1,0 +1,15 @@
+{
+  "Pagination": {
+    "future_url": null,
+    "newer_url": "/v1/user/1/monetary-account/2/payment?count=1&newer_id=170",
+    "older_url": null
+  },
+
+  "Response": [
+    {
+      "Payment": {
+        "id": 170
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Use either older or newer to page backward or foward.

Fixes #17 

Better late than never...