### PR TITLE
Add session caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ Bunq.client.me_as_user.monetary_accounts.index.each do |monetary_account|
 end
 ```
 
+## Session caching
+
+By default, each `Bunq.client` creates a new session. If you want to share a session between multiple
+`Bunq.client`s, use the following configuration:
+
+```
+Bunq.configure do |config|
+  config.session_cache = Bunq::ThreadSafeSessionCache.new
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/bunq-client.gemspec
+++ b/bunq-client.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jorttbv/bunq-client"
   spec.license       = "MIT"
 
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -33,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
+  spec.add_runtime_dependency 'thread_safe', '~> 0.3.6'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -50,18 +50,10 @@ module Bunq
     end
 
     ##
-    # Returns either a new instance of +Client+ with the current +configuration+ or a cached +Client+,
-    # depending on the +Configuration#cache_client+ setting.
+    # Returns a new instance of +Client+ with the current +configuration+.
     #
     def client
       fail "No configuration! Call Bunq.configure first." unless configuration
-      return new_client unless configuration.cache_client
-      @cached_client ||= new_client
-    end
-
-    private
-
-    def new_client
       Client.new(configuration)
     end
   end
@@ -94,7 +86,6 @@ module Bunq
     DEFAULT_GEOLOCATION = '0 0 0 0 000'
     DEFAULT_USER_AGENT = "bunq ruby client #{Bunq::VERSION}"
     DEFAULT_TIMEOUT = 60
-    DEFAULT_CACHE_CLIENT = false
 
     # Base url for the bunq api. Defaults to +PRODUCTION_BASE_URL+
     attr_accessor :base_url,
@@ -128,8 +119,6 @@ module Bunq
       :server_public_key,
       # Timeout in seconds to wait for bunq api. Defaults to +DEFAULT_TIMEOUT+
       :timeout,
-      # Whether or not to cache client instances created by +Bunq.client+. Defaults to +DEFAULT_CACHE_CLIENT+.
-      :cache_client,
       :session_cache
 
     def initialize
@@ -141,7 +130,6 @@ module Bunq
       @user_agent = DEFAULT_USER_AGENT
       @disable_response_signature_verification = false
       @timeout = DEFAULT_TIMEOUT
-      @cache_client = DEFAULT_CACHE_CLIENT
       @session_cache = ThreadSafeSessionCache.new
     end
   end
@@ -151,6 +139,7 @@ module Bunq
   #
   # An instance of a +Client+ can be obtained via +Bunq.client+
   class Client
+
     attr_accessor :current_session
     attr_reader :configuration
 

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -49,10 +49,18 @@ module Bunq
     end
 
     ##
-    # Returns a new instance of +Client+ with the current +configuration+.
+    # Returns either a new instance of +Client+ with the current +configuration+ or a cached +Client+,
+    # depending on the +Configuration#cache_client+ setting.
     #
     def client
       fail "No configuration! Call Bunq.configure first." unless configuration
+      return new_client unless configuration.cache_client
+      @cached_client ||= new_client
+    end
+
+    private
+
+    def new_client
       Client.new(configuration)
     end
   end
@@ -69,6 +77,7 @@ module Bunq
     DEFAULT_GEOLOCATION = '0 0 0 0 000'
     DEFAULT_USER_AGENT = "bunq ruby client #{Bunq::VERSION}"
     DEFAULT_TIMEOUT = 60
+    DEFAULT_CACHE_CLIENT = false
 
     # Base url for the bunq api. Defaults to +PRODUCTION_BASE_URL+
     attr_accessor :base_url,
@@ -101,7 +110,9 @@ module Bunq
       # The public key of this installation for verifying the response
       :server_public_key,
       # Timeout in seconds to wait for bunq api. Defaults to +DEFAULT_TIMEOUT+
-      :timeout
+      :timeout,
+      # Whether or not to cache client instances created by +Bunq.client+. Defaults to +DEFAULT_CACHE_CLIENT+.
+      :cache_client
 
     def initialize
       @sandbox = false
@@ -112,6 +123,7 @@ module Bunq
       @user_agent = DEFAULT_USER_AGENT
       @disable_response_signature_verification = false
       @timeout = DEFAULT_TIMEOUT
+      @cache_client = DEFAULT_CACHE_CLIENT
     end
   end
 
@@ -120,7 +132,6 @@ module Bunq
   #
   # An instance of a +Client+ can be obtained via +Bunq.client+
   class Client
-
     attr_accessor :current_session
     attr_reader :configuration
 

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -165,7 +165,6 @@ module Bunq
   #
   # An instance of a +Client+ can be obtained via +Bunq.client+
   class Client
-
     attr_accessor :current_session
     attr_reader :configuration
 

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -58,6 +58,16 @@ module Bunq
     end
   end
 
+  class NoSessionCache
+    def get(&block)
+      block.call if block_given?
+    end
+
+    def clear
+      # no-op
+    end
+  end
+
   class ThreadSafeSessionCache
     CACHE_KEY = 'CURRENT_BUNQ_SESSION'
 
@@ -86,6 +96,7 @@ module Bunq
     DEFAULT_GEOLOCATION = '0 0 0 0 000'
     DEFAULT_USER_AGENT = "bunq ruby client #{Bunq::VERSION}"
     DEFAULT_TIMEOUT = 60
+    DEFAULT_SESSION_CACHE = NoSessionCache.new
 
     # Base url for the bunq api. Defaults to +PRODUCTION_BASE_URL+
     attr_accessor :base_url,
@@ -119,6 +130,9 @@ module Bunq
       :server_public_key,
       # Timeout in seconds to wait for bunq api. Defaults to +DEFAULT_TIMEOUT+
       :timeout,
+      # Cache to retrieve sessions from. Defaults to +DEFAULT_SESSION_CACHE+,
+      # which will create a new session per `Bunq.client` instance.
+      # See +ThreadSafeSessionCache+ for more advanced use.
       :session_cache
 
     def initialize
@@ -130,7 +144,7 @@ module Bunq
       @user_agent = DEFAULT_USER_AGENT
       @disable_response_signature_verification = false
       @timeout = DEFAULT_TIMEOUT
-      @session_cache = ThreadSafeSessionCache.new
+      @session_cache = DEFAULT_SESSION_CACHE
     end
   end
 

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -68,6 +68,18 @@ module Bunq
     end
   end
 
+  ##
+  # A thread-safe session cache that can hold one (the current) session.
+  #
+  # Usage:
+  #
+  # Bunq.configure do |config|
+  #   config.session_cache = Bunq::ThreadSafeSessionCache.new
+  # end
+  #
+  # After this, all +Bunq.client+ calls will use the same session. When the session times out,
+  # a new one is started automatically.
+  #
   class ThreadSafeSessionCache
     CACHE_KEY = 'CURRENT_BUNQ_SESSION'
 

--- a/lib/bunq/client.rb
+++ b/lib/bunq/client.rb
@@ -142,7 +142,7 @@ module Bunq
       :server_public_key,
       # Timeout in seconds to wait for bunq api. Defaults to +DEFAULT_TIMEOUT+
       :timeout,
-      # Cache to retrieve sessions from. Defaults to +DEFAULT_SESSION_CACHE+,
+      # Cache to retrieve current session from. Defaults to +DEFAULT_SESSION_CACHE+,
       # which will create a new session per `Bunq.client` instance.
       # See +ThreadSafeSessionCache+ for more advanced use.
       :session_cache

--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -28,5 +28,6 @@ module Bunq
   class UnexpectedResponse < ResponseError; end
   class AbsentResponseSignature < ResponseError; end
   class TooManyRequestsResponse < ResponseError; end
+  class UnauthorisedResponse < ResponseError; end
   class Timeout < StandardError; end
 end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -117,6 +117,8 @@ module Bunq
         end
       elsif (response.code == 409 && Bunq.configuration.sandbox) || response.code == 429
         fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
+      elsif response.code == 401
+        fail UnauthorisedResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       else
         fail UnexpectedResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -10,22 +10,10 @@ module Bunq
     def initialize(client, path)
       @client = client
       @path = path
-      @resource = RestClient::Resource.new(
-        "#{client.configuration.base_url}#{path}",
-        {
-          headers: client.headers,
-          timeout: client.configuration.timeout,
-        }.tap do |x|
-          if client.configuration.sandbox
-            x[:user] = client.configuration.sandbox_user
-            x[:password] = client.configuration.sandbox_password
-          end
-        end
-      )
     end
 
     def get(params = {}, &block)
-      @resource.get({params: params}.merge(bunq_request_headers('GET', params))) do |response, request, result|
+      resource.get({params: params}.merge(bunq_request_headers('GET', params))) do |response, request, result|
         verify_and_handle_response(response, request, result, &block)
       end
     rescue RestClient::Exceptions::Timeout
@@ -39,7 +27,7 @@ module Bunq
 
       headers = bunq_request_headers('POST', NO_PARAMS, body, headers || {})
 
-      @resource.post(body, headers) do |response, request, result|
+      resource.post(body, headers) do |response, request, result|
         if skip_verify
           handle_response(response, request, result, &block)
         else
@@ -56,7 +44,7 @@ module Bunq
 
       headers = bunq_request_headers('PUT', NO_PARAMS, body, headers || {})
 
-      @resource.put(body, headers) do |response, request, result|
+      resource.put(body, headers) do |response, request, result|
         verify_and_handle_response(response, request, result, &block)
       end
     rescue RestClient::Exceptions::Timeout
@@ -73,7 +61,22 @@ module Bunq
 
     private
 
-    attr_reader :client
+    attr_reader :client, :path
+
+    def resource
+      RestClient::Resource.new(
+        "#{client.configuration.base_url}#{path}",
+        {
+          headers: client.headers,
+          timeout: client.configuration.timeout,
+        }.tap do |x|
+          if client.configuration.sandbox
+            x[:user] = client.configuration.sandbox_user
+            x[:password] = client.configuration.sandbox_password
+          end
+        end
+      )
+    end
 
     def bunq_request_headers(verb, params, payload = nil, headers = {})
       headers['X-Bunq-Client-Request-Id'] = SecureRandom.uuid
@@ -89,7 +92,7 @@ module Bunq
       client.signature.create(
         verb,
         encode_params(@path, params),
-        @resource.headers.merge(headers),
+        resource.headers.merge(headers),
         payload
       )
     end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -67,10 +67,6 @@ module Bunq
       Bunq::Resource.new(client, @path + path)
     end
 
-    def ensure_session!
-      client.ensure_session!
-    end
-
     def with_session(&block)
       client.with_session(&block)
     end

--- a/spec/bunq/client_spec.rb
+++ b/spec/bunq/client_spec.rb
@@ -2,19 +2,6 @@ require 'spec_helper'
 require 'rspec/json_expectations'
 
 describe Bunq::Client do
-  describe '.client' do
-    context 'given default configuration' do
-      it 'creates a new instance' do
-        expect(Bunq.client).to_not equal(Bunq.client)
-      end
-    end
 
-    context 'given configuration with cache_client = true' do
-      before { Bunq.configure { |config| config.cache_client = true } }
 
-      it 'returns the cached client' do
-        expect(Bunq.client).to equal(Bunq.client)
-      end
-    end
-  end
 end

--- a/spec/bunq/client_spec.rb
+++ b/spec/bunq/client_spec.rb
@@ -2,6 +2,19 @@ require 'spec_helper'
 require 'rspec/json_expectations'
 
 describe Bunq::Client do
+  describe '.client' do
+    context 'given default configuration' do
+      it 'creates a new instance' do
+        expect(Bunq.client).to_not equal(Bunq.client)
+      end
+    end
 
+    context 'given configuration with cache_client = true' do
+      before { Bunq.configure { |config| config.cache_client = true } }
 
+      it 'returns the cached client' do
+        expect(Bunq.client).to equal(Bunq.client)
+      end
+    end
+  end
 end

--- a/spec/bunq/fixtures/session-timeout.json
+++ b/spec/bunq/fixtures/session-timeout.json
@@ -1,0 +1,8 @@
+{
+    "Error": [
+        {
+            "error_description": "Session timeout",
+            "error_description_translated": "Session timeout"
+        }
+    ]
+}

--- a/spec/bunq/fixtures/session-timeout.json
+++ b/spec/bunq/fixtures/session-timeout.json
@@ -1,8 +1,8 @@
 {
-    "Error": [
-        {
-            "error_description": "Session timeout",
-            "error_description_translated": "Session timeout"
-        }
-    ]
+  "Error": [
+    {
+      "error_description": "Insufficient authorisation.",
+      "error_description_translated": "Onvoldoende autorisatie."
+    }
+  ]
 }

--- a/spec/bunq/monetary_accounts_spec.rb
+++ b/spec/bunq/monetary_accounts_spec.rb
@@ -10,21 +10,9 @@ describe Bunq::MonetaryAccounts do
     let(:response) { IO.read('spec/bunq/fixtures/monetary_account.list.json') }
 
     it 'returns a list of monetary accounts' do
-      client.configuration.user_agent = 'bunq ruby client 0.1.2'
-      expect(SecureRandom).to receive(:uuid).twice.and_return('foo')
-
-
       stub_request(:get, "#{user_url}/monetary-account")
-        .with(
-          query: {count: 200},
-          headers: {
-            'X-Bunq-Client-Request-Id' => 'foo',
-            'X-Bunq-Client-Signature' => 'aUdpwr1KGKWWKJOC2Zk34Ehg0JGwWx0zf1OOZyFo+ZncnsX7UWzWXyvMKUxar6cEzwK7hSRVrsXPR8E/pZKL/4KGyW4c32drIeBOFBq8tFWGLgYgSpsRpjuWDny1SiFCI08jM5Mj3puLGAiJ2nI46aLLpKASOIqhO5n++Yb4eJPbm/h3fqLn3YfTw7AlEswO0K0SFu5xvqkk40VLlhjaU6i85gRcQCqxr2bcOgyDI0xhjHR8elWrIJBaMax5d5AX17Rvcq3ejrDBw4ZPUaTe27ifRbWqq/bP6f+H6TAqcegHFVO1JOmLiMsZdBfEjlSiV2IUYZLHsmR/lNejxyO82Q=='
-          }
-        )
-        .to_return({
-          body: response
-        })
+        .with(query: {count: 200},)
+        .to_return({body: response})
 
       result = user.monetary_accounts.index
       expect(result.to_a).to include_json ([{"MonetaryAccountBank": {"id": 42}}])

--- a/spec/bunq/resource_spec.rb
+++ b/spec/bunq/resource_spec.rb
@@ -6,7 +6,7 @@ describe Bunq::Resource do
   let(:client) { Bunq.client }
   let(:url) { "#{client.configuration.base_url}" }
 
-  let(:resource) { Bunq::Resource.new(client, '/timeout') }
+  let(:resource) { Bunq::Resource.new(client, '/resource') }
 
   context 'timeouts' do
     it 'has a default timeout of 60 seconds' do
@@ -14,19 +14,19 @@ describe Bunq::Resource do
     end
 
     it 'handles timeouts for get' do
-      stub_request(:get, "#{url}/timeout").to_timeout
+      stub_request(:get, "#{url}/resource").to_timeout
 
       expect { resource.get }.to(raise_error(Bunq::Timeout)) { |e| expect(e.cause).to be_a_kind_of RestClient::Exceptions::Timeout }
     end
 
     it 'handles timeouts for put' do
-      stub_request(:put, "#{url}/timeout").to_timeout
+      stub_request(:put, "#{url}/resource").to_timeout
 
       expect { resource.put({}) }.to(raise_error(Bunq::Timeout)) { |e| expect(e.cause).to be_a_kind_of RestClient::Exceptions::Timeout }
     end
 
     it 'handles timeouts for post' do
-      stub_request(:post, "#{url}/timeout").to_timeout
+      stub_request(:post, "#{url}/resource").to_timeout
 
       expect { resource.post({}) }.to(raise_error(Bunq::Timeout)) { |e| expect(e.cause).to be_a_kind_of RestClient::Exceptions::Timeout }
     end
@@ -40,7 +40,7 @@ describe Bunq::Resource do
     end
 
     it 'fails' do
-      stub_request(:get, "#{url}/timeout")
+      stub_request(:get, "#{url}/resource")
         .to_return({ status: 409 })
 
       expect { resource.get({}) }.to raise_error(Bunq::TooManyRequestsResponse)
@@ -49,10 +49,19 @@ describe Bunq::Resource do
 
   context 'too many requests production response' do
     it 'fails' do
-      stub_request(:get, "#{url}/timeout")
+      stub_request(:get, "#{url}/resource")
         .to_return({ status: 429 })
 
       expect { resource.get({}) }.to raise_error(Bunq::TooManyRequestsResponse)
+    end
+  end
+
+  describe 'given a response with status code 401 Unauthorized' do
+    it 'raises a Bunq::UnauthorisedResponse' do
+      stub_request(:get, "#{url}/resource")
+        .to_return({ status: 401 })
+
+      expect { resource.get({}) }.to raise_error(Bunq::UnauthorisedResponse)
     end
   end
 end

--- a/spec/bunq/session_spec.rb
+++ b/spec/bunq/session_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'Bunq sessions' do
+  let(:client) { Bunq.client }
+  let(:another_client) { Bunq.client }
+
+  before do
+    stub_request(:get, "#{client.configuration.base_url}/v1/user/42")
+      .to_return(body: IO.read('spec/bunq/fixtures/user.get.json'))
+  end
+
+  context 'given the default session cache' do
+    let(:session_cache) { client.configuration.session_cache }
+
+    before do
+      stub_request(:post, "#{client.configuration.base_url}/v1/session-server")
+        .to_return(body: IO.read('spec/bunq/fixtures/session_server.post.json'))
+    end
+
+    it 'creates a new session per client instance' do
+      expect(session_cache)
+        .to receive(:get)
+        .twice
+        .and_return(JSON.parse(IO.read('spec/bunq/fixtures/session_server.post.json'))['Response'])
+
+      client.me_as_user.show
+      another_client.me_as_user.show
+    end
+  end
+
+  context 'given a configured session cache' do
+    let(:session_cache) { Bunq::ThreadSafeSessionCache.new }
+
+    before do
+      Bunq.configure do |config|
+        config.session_cache = session_cache
+      end
+    end
+
+    before do
+      stub_request(:post, "#{client.configuration.base_url}/v1/session-server")
+        .to_return(body: IO.read('spec/bunq/fixtures/session_server.post.json'))
+    end
+
+    it 'shares the session from the cache between client instances' do
+      client.me_as_user.show
+      first_session = session_cache.get
+      expect(first_session).to_not be_nil
+
+      another_client.me_as_user.show
+      second_session = session_cache.get
+      expect(second_session).to_not be_nil
+
+      expect(first_session).to eq(second_session)
+    end
+
+    context 'and a session timeout' do
+      before do
+        stub_request(:get, "#{client.configuration.base_url}/v1/user/42")
+          .to_return(status: 401, body: IO.read('spec/bunq/fixtures/session-timeout.json'))
+      end
+
+      it 'clears the session from the cache' do
+        expect { client.me_as_user.show }.to raise_error(Bunq::UnauthorisedResponse)
+        expect(session_cache.get).to be_nil
+      end
+
+      context 'and another client performs a call' do
+        it 'succeeds' do
+          expect { client.me_as_user.show }.to raise_error(Bunq::UnauthorisedResponse)
+
+          stub_request(:get, "#{client.configuration.base_url}/v1/user/42")
+            .to_return(body: IO.read('spec/bunq/fixtures/user.get.json'))
+
+          another_client.me_as_user.show
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ RSpec.configure do |config|
   config.include RequiresSessionExampleGroup, :requires_session
 
   config.before do
+    Bunq.reset_configuration
+
     Bunq.configure do |c|
       c.disable_response_signature_verification = true
       c.installation_token = 'foo'
@@ -45,6 +47,5 @@ RSpec.configure do |config|
 
   config.after :each, :requires_session do
     expect(session_stub).to have_been_requested
-    Bunq.reset_configuration
   end
 end


### PR DESCRIPTION
Current behavior (always new session per `Bunq.client`) is backward compatible.

If you want to share a session between `Bunq.client` calls, use the following:

```
Bunq.configure do |config|
  config.session_cache = Bunq::ThreadSafeSessionCache.new
end
```

In case a (cached) session is timed out, a new session is started automatically.