### PR TITLE
Only sign the body of requests

### DIFF
--- a/lib/bunq/errors.rb
+++ b/lib/bunq/errors.rb
@@ -26,6 +26,7 @@ module Bunq
   end
 
   class UnexpectedResponse < ResponseError; end
+  class RequestSignatureRequired < ResponseError; end
   class AbsentResponseSignature < ResponseError; end
   class TooManyRequestsResponse < ResponseError; end
   class UnauthorisedResponse < ResponseError; end

--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -89,12 +89,7 @@ module Bunq
     end
 
     def sign_request(verb, params, headers, payload = nil)
-      client.signature.create(
-        verb,
-        encode_params(@path, params),
-        resource.headers.merge(headers),
-        payload
-      )
+      client.signature.create(payload)
     end
 
     def encode_params(path, params)

--- a/lib/bunq/signature.rb
+++ b/lib/bunq/signature.rb
@@ -30,7 +30,7 @@ module Bunq
       fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body) unless signature_headers_value
 
       signature = Base64.strict_decode64(signature_headers_value.first)
-      fail UnexpectedResponse.new(code: response.code, headers: response.raw_headers, body: response.body) unless server_public_key.verify(digest, signature, response.body)
+      fail RequestSignatureRequired.new(code: response.code, headers: response.raw_headers, body: response.body) unless server_public_key.verify(digest, signature, response.body)
     end
 
     private

--- a/lib/bunq/signature.rb
+++ b/lib/bunq/signature.rb
@@ -24,13 +24,19 @@ module Bunq
       return if skip_signature_check(response.code)
 
       signature_headers = response.raw_headers.find { |k, _| k.to_s.downcase == BUNQ_SERVER_SIGNATURE_RESPONSE_HEADER }
-      fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body) unless signature_headers
+      unless signature_headers
+        fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body)
+      end
 
       signature_headers_value = signature_headers[1]
-      fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body) unless signature_headers_value
+      unless signature_headers_value
+        fail AbsentResponseSignature.new(code: response.code, headers: response.raw_headers, body: response.body)
+      end
 
       signature = Base64.strict_decode64(signature_headers_value.first)
-      fail RequestSignatureRequired.new(code: response.code, headers: response.raw_headers, body: response.body) unless server_public_key.verify(digest, signature, response.body)
+      unless server_public_key.verify(digest, signature, response.body)
+        fail RequestSignatureRequired.new(code: response.code, headers: response.raw_headers, body: response.body)
+      end
     end
 
     private

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -43,10 +43,6 @@ describe Bunq::Signature do
   describe 'response verification' do
     let(:server_private_key) { OpenSSL::PKey::RSA.new(IO.read('spec/bunq/fixtures/server-test-private.pem')) }
     let(:signable_response) do
-      "200\n" \
-      "X-Bunq-Client-Request-Id: 57061b04b67ef\n" \
-      "X-Bunq-Server-Response-Id: 89dcaa5c-fa55-4068-9822-3f87985d2268\n" \
-      "\n" \
       "{\"Response\":[{\"Id\":{\"id\":1561}}]}"
     end
     let(:server_signature) do
@@ -62,13 +58,12 @@ describe Bunq::Signature do
         :'X-Bunq-Server-Response-Id' => ['89dcaa5c-fa55-4068-9822-3f87985d2268'],
       }
     end
-    let(:code) { 200 }
     let(:body) { '{"Response":[{"Id":{"id":1561}}]}' }
 
     let(:response) do
       double(
         raw_headers: headers,
-        code: code,
+        code: 200,
         body: body
       )
     end
@@ -79,7 +74,7 @@ describe Bunq::Signature do
     end
 
     context 'given a tampered response' do
-      let(:code) { 404 }
+      let(:body) { '{"Response":[{"Id":{"id":TAMPERED}}]}' }
 
       it 'fails' do
         expect { subject }.to raise_error(Bunq::UnexpectedResponse)

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -2,59 +2,19 @@ require 'spec_helper'
 
 describe Bunq::Signature do
   context do
-    let(:verb) { 'GET' }
-    let(:path) { '/' }
-    let(:signable_headers) do
-      {
-        'Cache-Control': 'no-cache',
-        'User-Agent': 'bunq-TestServer/1.00 sandbox/0.17b3',
-        'X-Bunq-Client-Authentication': 'f15f1bbe1feba25efb00802fa127042b54101c8ec0a524c36464f5bb143d3b8b',
-        'X-Bunq-Client-Request-Id': '57061b04b67ef',
-        'X-Bunq-Geolocation': '0 0 0 0 NL',
-        'X-Bunq-Language': 'en_US',
-        'X-Bunq-Region': 'en_US',
-      }
-    end
-    let(:headers) { signable_headers }
     let(:body) { '{"amount": 10}' }
 
-    subject { Bunq.client.signature.create(verb, path, headers, body) }
+    subject { Bunq.client.signature.create(body) }
 
     let(:expected_signature) do
-      'o5AXc4Ag72GzfzXwDbvlEck3SnrEILHVjmc6wJhjZVGn+rtPmAilCKQiSvneo2VbjwuP2vHJdZEQk4NF/1PmrVByUjdmCF/' \
-      'c9y5LP/w4+SgZMoyu6DfzDtoVRMMFM0tC4MPVaAZ8//vniQEaR7EK3RBL5Nh4dUnA3UVQ972SbTl+Huof5XknUlONOpzSU+' \
-      'ms3VIj8FmogzfRmjnJoDUvfwxY+5mRhQDi9wD+nAXPUo2yT2OL1by/RkE5bfLlBbZXmUwXYMQ8IHAF7Rnow8aBY7FCjl8Ye' \
-      'Sulw58bPOb9HJJM3lk0ZaPisN/S1HbwQ9LcRLX0SdSuKlvnu2U/uZv8AA=='
+      'qB/d2z/78SxyOXDOLHVgoalmcINnDggiGlMLyh5Kf/pDkG9Qs2JCSk/QjOwGQ/h4b0K6MWA4OLVrmzIUbbF++/sYNs+sEK4PVOUATKMOjShWn' \
+      'Z4NHUU9HqoS3ruAdV6XU5LFjvpqsUQ/egXAGzFlUgPaq4g2t8P8hQHKH9C2SJjCOLAt07VleaiQRlPdyyEmmNMfxbp4bFe3EP62ILFz4t/4ox' \
+      'ZRDchXWAAAUT6DnIiXuimBNRebi0Nsk32IIdieDeOcjrppIx2BIN0jNLULzLbiE9hsV9XwjNMYU6+SCQDQMLweRXgggB8wPJBK9sApdSdhkmS' \
+      'ZeNE1sOdRG12F+g=='
     end
 
     it 'can be created from an HTTP request' do
       expect(subject).to eq(expected_signature)
-    end
-
-    context 'given a header other than Cache-Control, User-Agent and X-Bunq-*' do
-      let(:headers) { signable_headers.merge('Accept': '*/*', 'Content-Type': 'application/json') }
-
-      it 'omits that header from the signature ' do
-        expect(subject).to eq(expected_signature)
-      end
-    end
-
-    context 'given a different HTTP verb' do
-      let(:verb) { 'POST' }
-
-      it 'creates a different signature' do
-        expect(subject).to_not be_nil
-        expect(subject).to_not eq(expected_signature)
-      end
-    end
-
-    context 'given a different HTTP path' do
-      let(:path) { '/installation' }
-
-      it 'creates a different signature' do
-        expect(subject).to_not be_nil
-        expect(subject).to_not eq(expected_signature)
-      end
     end
 
     context 'given a different HTTP body' do

--- a/spec/bunq/signature_spec.rb
+++ b/spec/bunq/signature_spec.rb
@@ -77,7 +77,7 @@ describe Bunq::Signature do
       let(:body) { '{"Response":[{"Id":{"id":TAMPERED}}]}' }
 
       it 'fails' do
-        expect { subject }.to raise_error(Bunq::UnexpectedResponse)
+        expect { subject }.to raise_error(Bunq::RequestSignatureRequired)
       end
     end
 


### PR DESCRIPTION
See: https://doc.bunq.com/#topic-signing

We also received a notice from the Bunq API development team:

Hey Developer,

We are thrilled to tell you we have made the bunq API easier to use.
What’s new
Request signing has become mandatory only for creating a session and making a payment. The use of signing for other API requests is optional.
We have deprecated the signing of the entire API request (the URL, headers and body). Requests with full request signatures will stop being validated on April 28, 2020. Please switch to signing the body solely by that date.
The following headers are now optional:
X-Bunq-Geolocation;
X-Bunq-Language (en_US is the default language setting for responses and error descriptions);
X-Bunq-Region (en_US is the default region for currency formatting);
X-Bunq-Request-Id.
We have extended the OAuth scopes with the following permissions:
create payment requests using the request-inquiry API resource;
create monetary accounts (bank, savings, and joint ones);
order cards;
manage cards.
We have deprecated additional encryption.
What this means for you as our partner
Your integration with the bunq API is safe. All you need to do is switch to only signing the request body by removing a few lines of code by April 28, 2020. This will take your developers 5 minutes. If you use our SDKs, just upgrade to version 1.13.1 that is coming out on February 12, 2020.
You can also choose to implement the new OAuth scopes or stop sending us the X-Bunq-Geolocation, X-Bunq-Language, X-Bunq-Region, and X-Bunq-Request-Id headers.
More information can be found in our docs. Please do not hesitate to reach out to us if you have any questions via GitHub or Together!
Does your team member miss bunq API updates? They can subscribe to our API newsletter too. 😉 You can also always check our Changelog in between the newsletters.