### PR TITLE
Raise Bunq::UnauthorisedResponse for 403

### DIFF
--- a/lib/bunq/resource.rb
+++ b/lib/bunq/resource.rb
@@ -118,7 +118,7 @@ module Bunq
         end
       elsif (response.code == 409 && Bunq.configuration.sandbox) || response.code == 429
         fail TooManyRequestsResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
-      elsif response.code == 401
+      elsif [401, 403].include?(response.code)
         fail UnauthorisedResponse.new(code: response.code, headers: response.raw_headers, body: response.body)
       elsif response.code == 404
         fail ResourceNotFound.new(code: response.code, headers: response.raw_headers, body: response.body)

--- a/spec/bunq/resource_spec.rb
+++ b/spec/bunq/resource_spec.rb
@@ -65,6 +65,15 @@ describe Bunq::Resource do
     end
   end
 
+  describe 'given a response with status code 403 Forbidden' do
+    it 'raises a Bunq::UnauthorisedResponse' do
+      stub_request(:get, "#{url}/resource")
+        .to_return({ status: 403 })
+
+      expect { resource.get({}) }.to raise_error(Bunq::UnauthorisedResponse)
+    end
+  end
+
   describe 'given a maintenance response' do
     let(:maintenance_html) do
       <<~HTML


### PR DESCRIPTION
When a session token becomes invalid, the Bunq API can respond with a
403 and the following body:

{"Error":[{"error_description":"Insufficient authentication.","error_description_translated":"Insufficient authentication."}]}

By raising a Bunq::UnauthorisedResponse, the session (and token)
will be cleared and the API call will be retried (resulting in a new and
valid session token).